### PR TITLE
Rename Usage to Example and then link to existing Example section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ without express.
 To our knowledge, `express-pino-logger` is the [fastest](#benchmarks) [express](http://npm.im/express) logger in town.
 
 * [Installation](#install)
-* [Usage](#usage)
+* [Example](#example)
 * [Benchmarks](#benchmarks)
 * [API](#api)
 * [Team](#team)


### PR DESCRIPTION
Before there was Usage title which I guess was linking to Usage example. The current Usage link is not functional. This PR link renames Usage to Example and links to the existing Example section.